### PR TITLE
Add test  should be able to change date  (example works directly on firefox)

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -45,6 +45,34 @@ it.only("MATERIAL UI WITH USE STATE  - should be able to change date", async () 
   expect(datum).toHaveValue("12/16/2020");
 });
 
+it.only("MATERIAL UI WITH USE STATE  - should be able to change date (example works directly on firefox)", async () => {
+  render(<App />);
+
+  const form = screen.getByTestId("mui-with-state");
+  const datum = within(form).getByRole("textbox");
+  // const datum = within(form).getByTestId("mui-textfield");
+  expect(datum).toHaveValue("12/28/2020");
+  
+  // If you paste this code into Firefox it will work
+  var date = document.querySelector('[data-testid=mui-with-state]')!.querySelector('input');
+  var evt = document.createEvent("HTMLEvents");
+  evt.initEvent("focus", false, true);
+  date!.dispatchEvent(evt);
+  var nativeInputValueSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")!.set;
+  nativeInputValueSetter!.call(date, '12/16/2020');
+
+  var ev2 = new Event('input', { bubbles: true});
+  date!.dispatchEvent(ev2);
+  // End paste
+
+  userEvent.click(within(form).getByTestId("submitButton"));
+  
+  const msg = within(form).getByTestId("submittedDate");
+  expect(msg).toBeInTheDocument();
+  expect(datum).toHaveValue("12/16/2020");
+  expect(msg.textContent).toBe("2020-12-16T23:00:00.000Z");
+});
+
 it("NATIVE TEXT FIELD - should paste date into native date input field", async () => {
   render(<App />);
 


### PR DESCRIPTION
If the code provided is used directly on a browser, works great. Against jsdom it doesn't